### PR TITLE
Use youtube_dl as the main downloader

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name="TUEDownloader",
     version="0.1",
     packages=find_packages(),
-    install_requires=['beautifulsoup4', 'requests'],
+    install_requires=['beautifulsoup4', 'requests', 'youtube_dl'],
     entry_points = {
         "console_scripts": [
             "tuedownloader = tuedownloader.download:main"

--- a/tuedownloader/download.py
+++ b/tuedownloader/download.py
@@ -11,6 +11,7 @@ import sys
 import configparser
 import argparse
 import os
+import youtube_dl
 from tuedownloader import util
 
 
@@ -217,30 +218,12 @@ class TUEDownloader(object):
                 print('{} already found, skipping...'.format(file_name))
                 continue
 
+            ytdl_opts = {
+                    'outtmpl': file_name
+            }
             try:
-                with open(file_name, "wb") as f:
-                    print(
-                        "Downloading {} saving to {}".format(
-                            video_url,
-                            file_name)
-                        )
-                    response = requests.get(video_url, stream=True)
-                    total_length = response.headers.get('content-length')
-
-                    if total_length is None:  # no content length header
-                        f.write(response.content)
-                    else:
-                        dl = 0
-                        total_length = int(total_length)
-                        for data in response.iter_content(chunk_size=4096):
-                            dl += len(data)
-                            f.write(data)
-                            done = int(50 * dl / total_length)
-                            sys.stdout.write(
-                                    "\r[%s%s]" % ('=' * done, ' ' * (50-done))
-                                )
-                            sys.stdout.flush()
-                        print('\r\n')
+                 with youtube_dl.YoutubeDL(ytdl_opts) as ytdl:
+                    ytdl.download([video_url])
             except Exception:
                 if os.path.isfile(file_name):
                     os.remove(file_name)

--- a/tuedownloader/download.py
+++ b/tuedownloader/download.py
@@ -195,7 +195,7 @@ class TUEDownloader(object):
             })
 
         player_options = json.loads(r.text)
-        video_urls = set()
+        video_urls = []
         # TODO mimetype checks
         for stream in player_options['d']['Presentation']['Streams']:
             if 'VideoUrls' not in stream.keys():
@@ -203,7 +203,7 @@ class TUEDownloader(object):
 
             for video_url in stream['VideoUrls']:
                 try:
-                    video_urls.add(video_url['Location'])
+                    video_urls.append(video_url['Location'])
                 except KeyError:
                     continue
 
@@ -212,7 +212,7 @@ class TUEDownloader(object):
         if not os.path.isdir(video_dir):
             os.makedirs(video_dir)
 
-        for i, video_url in enumerate(video_urls):
+        for i, video_url in enumerate(video_urls[:2]):
             file_name = os.path.join(video_dir, "download_{}.mp4".format(i))
             if os.path.isfile(file_name):
                 print('{} already found, skipping...'.format(file_name))

--- a/tuedownloader/download.py
+++ b/tuedownloader/download.py
@@ -11,6 +11,7 @@ import sys
 import configparser
 import argparse
 import os
+import youtube_dl
 from tuedownloader import util
 
 
@@ -217,30 +218,12 @@ class TUEDownloader(object):
                 print('{} already found, skipping...'.format(file_name))
                 continue
 
+            ytdl_opts = {
+                'outtmpl': file_name
+            }
             try:
-                with open(file_name, "wb") as f:
-                    print(
-                        "Downloading {} saving to {}".format(
-                            video_url,
-                            file_name)
-                        )
-                    response = requests.get(video_url, stream=True)
-                    total_length = response.headers.get('content-length')
-
-                    if total_length is None:  # no content length header
-                        f.write(response.content)
-                    else:
-                        dl = 0
-                        total_length = int(total_length)
-                        for data in response.iter_content(chunk_size=4096):
-                            dl += len(data)
-                            f.write(data)
-                            done = int(50 * dl / total_length)
-                            sys.stdout.write(
-                                    "\r[%s%s]" % ('=' * done, ' ' * (50-done))
-                                )
-                            sys.stdout.flush()
-                        print('\r\n')
+                with youtube_dl.YoutubeDL(ytdl_opts) as ytdl:
+                    ytdl.download([video_url])
             except Exception:
                 if os.path.isfile(file_name):
                     os.remove(file_name)

--- a/tuedownloader/download.py
+++ b/tuedownloader/download.py
@@ -195,7 +195,7 @@ class TUEDownloader(object):
             })
 
         player_options = json.loads(r.text)
-        video_urls = []
+        video_urls = set()
         # TODO mimetype checks
         for stream in player_options['d']['Presentation']['Streams']:
             if 'VideoUrls' not in stream.keys():
@@ -203,7 +203,7 @@ class TUEDownloader(object):
 
             for video_url in stream['VideoUrls']:
                 try:
-                    video_urls.append(video_url['Location'])
+                    video_urls.add(video_url['Location'])
                 except KeyError:
                     continue
 
@@ -212,7 +212,7 @@ class TUEDownloader(object):
         if not os.path.isdir(video_dir):
             os.makedirs(video_dir)
 
-        for i, video_url in enumerate(video_urls[:2]):
+        for i, video_url in enumerate(video_urls):
             file_name = os.path.join(video_dir, "download_{}.mp4".format(i))
             if os.path.isfile(file_name):
                 print('{} already found, skipping...'.format(file_name))

--- a/tuedownloader/download.py
+++ b/tuedownloader/download.py
@@ -32,6 +32,11 @@ class TUEDownloader(object):
         self.password = password
         self.user_agent = user_agent
         self.session = None
+        self.supported_mime_types = [
+            "video/mp4",
+            "video/x-mpeg-dash",
+            "video/x-mp4-fragmented",
+        ]
 
     def get_session(self, login_url):
         self.session = requests.Session()
@@ -195,15 +200,20 @@ class TUEDownloader(object):
             })
 
         player_options = json.loads(r.text)
-        video_urls = set()
-        # TODO mimetype checks
+        # Contains a dict with available mimetypes and location urls
+        video_urls = {}
         for stream in player_options['d']['Presentation']['Streams']:
             if 'VideoUrls' not in stream.keys():
                 continue
 
             for video_url in stream['VideoUrls']:
                 try:
-                    video_urls.add(video_url['Location'])
+                    mime_type = video_url['MimeType'] 
+                    location = video_url['Location'] 
+                    if mime_type in video_urls:
+                        video_urls[mime_type].add(location)
+                    else:
+                        video_urls[mime_type] = {location}
                 except KeyError:
                     continue
 
@@ -212,7 +222,19 @@ class TUEDownloader(object):
         if not os.path.isdir(video_dir):
             os.makedirs(video_dir)
 
-        for i, video_url in enumerate(video_urls):
+        # Select which mimetype to use
+        for mime_type in self.supported_mime_types:
+            if mime_type in video_urls:
+                print(f"[i] Selected mime_type: {mime_type}")
+                supported_urls = video_urls[mime_type]
+                break
+
+        # TODO; This only allows for 1 mime_type per lecture,
+        # If for example, slides/screencast is recorded in another
+        # format, this won't work.
+        # However, I don't think that's a common case (exluding slide png's)
+
+        for i, video_url in enumerate(supported_urls):
             file_name = os.path.join(video_dir, "download_{}.mp4".format(i))
             if os.path.isfile(file_name):
                 print('{} already found, skipping...'.format(file_name))
@@ -223,6 +245,9 @@ class TUEDownloader(object):
             }
             try:
                 with youtube_dl.YoutubeDL(ytdl_opts) as ytdl:
+                    # TODO; Move this download out of the for loop.
+                    # YTDL takes a list of videos as argument, which it
+                    # Can download in parallel
                     ytdl.download([video_url])
 
             except Exception:


### PR DESCRIPTION
Hey there,

This PR swaps out your custom downloader with Youtube_DL to support newer lectures.    
  
Youtube DL is quite a bit larger, but also comes with extra features, such as support `.ism` files and the ability to resume downloads.  
  
Furthermore, **I limited the maximum number of downloads per lecture to 2.** I found that the `ism` downloads will sometimes contain many duplicate downloads. If there are cases where you need more downloads, you can revert that commit.
  
If you're interested, I also have a Python script for cropping combining both streams with ffmpeg. the output looks a like this (without the blur of course :P )
![image](https://user-images.githubusercontent.com/29239050/91872530-410fb300-ec78-11ea-9b46-b2bbf8599dbb.png)  
  
With a little effort that could be added as another step in the download.
